### PR TITLE
:recycle: [REFACTOR] CORS 에러 수정

### DIFF
--- a/src/main/java/com/prochord/server/global/exception/auth/SecurityConfig.java
+++ b/src/main/java/com/prochord/server/global/exception/auth/SecurityConfig.java
@@ -29,7 +29,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 추가
             .csrf(AbstractHttpConfigurer::disable)
             .formLogin(AbstractHttpConfigurer::disable)
             .requestCache(RequestCacheConfigurer::disable)
@@ -51,18 +50,6 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(true);
-        config.addAllowedOriginPattern("http://localhost:[*]"); // 특정 포트 범위 허용
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("*");
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", config);
-        return source;
     }
 
 }


### PR DESCRIPTION
NGINX를 사용하기 때문에 CORS 에러는 BE 서버 내에서 잡으면 안되고, nginx.conf에서 해결해야 리버스 프록시 라우팅이 작동할 수 있다. 